### PR TITLE
Clean up dnf cache completely on el8

### DIFF
--- a/daisy_workflows/image_build/enterprise_linux/kickstart/el8-post.cfg
+++ b/daisy_workflows/image_build/enterprise_linux/kickstart/el8-post.cfg
@@ -82,6 +82,7 @@ rm -f /etc/yum.repos.d/google-cloud-unstable.repo \
 
 # Clean up the cache for smaller images.
 dnf clean all
+rm -fr cd /var/cache/dnf/*
 
 # Blacklist the floppy module.
 echo "blacklist floppy" > /etc/modprobe.d/blacklist-floppy.conf


### PR DESCRIPTION
`dnf clean all` command do not clean everything stored in dnf cache.
At least it keeps fastestmirror dnf plugin cache that enabled on AlmaLinux by default.
So I propose to delete dnf cache completely during image build.